### PR TITLE
Organize sidebar settings into a nested hierarchy

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Upload from './pages/Upload';
 import Customers from './pages/Customers';
 import Analysis from './pages/Analysis';
 import Configuration from './pages/Configuration';
+import BatchProcessing from './pages/BatchProcessing';
 import Debug from './pages/Debug';
 import ErrorBoundary from './components/common/ErrorBoundary';
 
@@ -81,6 +82,7 @@ function App() {
                   <Route path="/customers" element={<Customers />} />
                   <Route path="/analysis" element={<Analysis />} />
                   <Route path="/configuration" element={<Configuration />} />
+                  <Route path="/batch-processing" element={<BatchProcessing />} />
                   {isDebugEnabled && <Route path="/debug" element={<Debug />} />}
                 </Routes>
               </main>

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { 
   HomeIcon, 
@@ -6,47 +6,109 @@ import {
   UsersIcon, 
   ChartBarIcon,
   Cog6ToothIcon,
-  BugAntIcon
+  BugAntIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ScaleIcon,
+  CpuChipIcon
 } from '@heroicons/react/24/outline';
 import { getUIText } from '../../utils/hebrewUtils';
 import { config } from '../../config/environment';
 
+interface NavigationItem {
+  name: string;
+  href?: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  children?: NavigationItem[];
+}
+
 const Sidebar: React.FC = () => {
   const isDebugEnabled = config.DEBUG_MODE;
+  const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set([getUIText('settings_nav')]));
 
-  const navigation = [
+  const toggleExpanded = (itemName: string) => {
+    const newExpanded = new Set(expandedItems);
+    if (newExpanded.has(itemName)) {
+      newExpanded.delete(itemName);
+    } else {
+      newExpanded.add(itemName);
+    }
+    setExpandedItems(newExpanded);
+  };
+
+  const navigation: NavigationItem[] = [
     { name: getUIText('dashboard_nav'), href: '/', icon: HomeIcon },
     { name: getUIText('upload_nav'), href: '/upload', icon: CloudArrowUpIcon },
     { name: getUIText('customers_nav'), href: '/customers', icon: UsersIcon },
     { name: getUIText('analysis_nav'), href: '/analysis', icon: ChartBarIcon },
-    { name: getUIText('configuration'), href: '/configuration', icon: Cog6ToothIcon },
+    { 
+      name: getUIText('settings_nav'), 
+      icon: Cog6ToothIcon,
+      children: [
+        { name: getUIText('scoring_settings'), href: '/configuration', icon: ScaleIcon },
+        { name: getUIText('batch_settings'), href: '/batch-processing', icon: CpuChipIcon },
+      ]
+    },
     // Only show debug navigation if debug mode is enabled
     ...(isDebugEnabled ? [{ name: 'Debug', href: '/debug', icon: BugAntIcon }] : []),
   ];
+
+  const renderNavigationItem = (item: NavigationItem, level: number = 0) => {
+    const hasChildren = item.children && item.children.length > 0;
+    const isExpanded = expandedItems.has(item.name);
+    const paddingLeft = level === 0 ? 'px-2' : 'px-6';
+
+    return (
+      <div key={item.name}>
+        {hasChildren ? (
+          <button
+            onClick={() => toggleExpanded(item.name)}
+            className={`group flex items-center w-full ${paddingLeft} py-2 text-sm font-medium rounded-md transition-colors rtl-nav-item hebrew-content text-gray-600 hover:bg-gray-50 hover:text-gray-900`}
+          >
+            <item.icon
+              className="ml-3 h-5 w-5"
+              aria-hidden="true"
+            />
+            <span className="flex-1 hebrew-content">{item.name}</span>
+            {isExpanded ? (
+              <ChevronDownIcon className="mr-2 h-4 w-4" />
+            ) : (
+              <ChevronRightIcon className="mr-2 h-4 w-4" />
+            )}
+          </button>
+        ) : (
+          <NavLink
+            to={item.href!}
+            className={({ isActive }) =>
+              `group flex items-center ${paddingLeft} py-2 text-sm font-medium rounded-md transition-colors rtl-nav-item hebrew-content ${level > 0 ? 'nested-item' : ''} ${
+                isActive
+                  ? 'bg-blue-50 text-blue-700 rtl-border-l border-blue-700 active'
+                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+              }`
+            }
+          >
+            <item.icon
+              className="ml-3 h-5 w-5"
+              aria-hidden="true"
+            />
+            <span className="hebrew-content">{item.name}</span>
+          </NavLink>
+        )}
+        
+        {hasChildren && isExpanded && (
+          <div className="mt-1 space-y-1">
+            {item.children!.map((child) => renderNavigationItem(child, level + 1))}
+          </div>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div className="w-64 bg-white shadow-sm rtl-sidebar">
       <nav className="mt-8 rtl-navigation">
         <div className="px-4 space-y-1">
-          {navigation.map((item) => (
-            <NavLink
-              key={item.name}
-              to={item.href}
-              className={({ isActive }) =>
-                `group flex items-center px-2 py-2 text-sm font-medium rounded-md transition-colors rtl-nav-item hebrew-content ${
-                  isActive
-                    ? 'bg-blue-50 text-blue-700 rtl-border-l border-blue-700'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                }`
-              }
-            >
-              <item.icon
-                className="ml-3 h-5 w-5"
-                aria-hidden="true"
-              />
-              <span className="hebrew-content">{item.name}</span>
-            </NavLink>
-          ))}
+          {navigation.map((item) => renderNavigationItem(item))}
         </div>
       </nav>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -56,6 +56,16 @@
   text-align: right;
 }
 
+/* Nested Navigation Styles */
+.rtl-navigation .nested-item {
+  border-right: 2px solid transparent;
+  margin-right: 1rem;
+}
+
+.rtl-navigation .nested-item.active {
+  border-right-color: #3b82f6;
+}
+
 .rtl-form {
   direction: rtl;
   text-align: right;

--- a/frontend/src/pages/BatchProcessing.tsx
+++ b/frontend/src/pages/BatchProcessing.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { getUIText } from '../utils/hebrewUtils';
+
+const BatchProcessing: React.FC = () => {
+  return (
+    <div className="space-y-6 rtl-layout">
+      <div className="flex justify-between items-center">
+        <h1 className="text-3xl font-bold text-gray-900 hebrew-content">
+          {getUIText('batch_settings')}
+        </h1>
+      </div>
+      
+      <div className="bg-white rounded-lg shadow p-6">
+        <p className="text-gray-600 hebrew-content">
+          הגדרות עיבוד מאוחד יתווספו כאן בקרוב
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default BatchProcessing;

--- a/frontend/src/utils/hebrewUtils.ts
+++ b/frontend/src/utils/hebrewUtils.ts
@@ -104,6 +104,9 @@ export const getUIText = (key: string): string => {
     'customers_nav': 'לקוחות',
     'analysis_nav': 'ניתוח',
     'upload_nav': 'העלאה',
+    'settings_nav': 'הגדרות',
+    'scoring_settings': 'הגדרות ציון',
+    'batch_settings': 'הגדרות עיבוד מאוחד',
     
     // Dashboard
     'recent_activity': 'פעילות אחרונה',


### PR DESCRIPTION
Organize sidebar settings into a nested, collapsible 'Settings' menu to improve navigation and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-de2fcc99-a76c-42d6-bbe8-fe96d112f92c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de2fcc99-a76c-42d6-bbe8-fe96d112f92c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

